### PR TITLE
Fix for zip codes with leading zeros

### DIFF
--- a/src/Lookup.php
+++ b/src/Lookup.php
@@ -5,7 +5,7 @@ use Ziptastic\Ziptastic\Service\ServiceInterface;
 
 class Lookup
 {
-    const ZIPTASTIC_LOOKUP_URL = 'https://zip.getziptastic.com/v3/%s/%d';
+    const ZIPTASTIC_LOOKUP_URL = 'https://zip.getziptastic.com/v3/%s/%s';
 
     /**
      * @var ServiceInterface;
@@ -42,12 +42,12 @@ class Lookup
 
     /**
      * Get information on given $zipCode
-     * @param  int                $zipCode
+     * @param  int|string         $zipCode
      * @return array[LookupModel]
      */
     public function lookup($zipCode)
     {
-        $url = sprintf(self::ZIPTASTIC_LOOKUP_URL, $this->countryCode, $zipCode);
+        $url = sprintf(self::ZIPTASTIC_LOOKUP_URL, $this->countryCode, (string) $zipCode);
         $res = $this->service->get($url, $this->apiKey);
 
         $collection = [];

--- a/src/Lookup.php
+++ b/src/Lookup.php
@@ -42,7 +42,7 @@ class Lookup
 
     /**
      * Get information on given $zipCode
-     * @param  int|string         $zipCode
+     * @param  string           $zipCode
      * @return array[LookupModel]
      */
     public function lookup($zipCode)

--- a/src/LookupModel.php
+++ b/src/LookupModel.php
@@ -25,7 +25,7 @@ class LookupModel
     private $stateShort;
 
     /**
-     * @var int
+     * @var int|string
      */
     private $postalCode;
 
@@ -95,7 +95,7 @@ class LookupModel
     }
 
     /**
-     * @return int
+     * @return int|string
      */
     public function postalCode()
     {

--- a/src/LookupModel.php
+++ b/src/LookupModel.php
@@ -25,7 +25,7 @@ class LookupModel
     private $stateShort;
 
     /**
-     * @var int|string
+     * @var string
      */
     private $postalCode;
 
@@ -95,7 +95,7 @@ class LookupModel
     }
 
     /**
-     * @return int|string
+     * @return string
      */
     public function postalCode()
     {


### PR DESCRIPTION
Without this change, zip codes with leading zeros (e.g. 02906) get stripped of their leading zero when implicitly typecasted to int. I've updated the sprintf format to accept a string zip code, and updated the PHP documentation to note either int or string can be passed (really, anything that's string-able).

Example:

``` php
$ziptastic = Lookup::create($apiKey);
var_dump($ziptastic->lookup('02906'));
```

Before change:

```
array (size=1)
  0 => 
    object(Ziptastic\Ziptastic\LookupModel)[3128]
      private 'county' => string 'DeKalb' (length=6)
      private 'city' => string 'Leslie Estates' (length=14)
      private 'state' => string 'Georgia' (length=7)
      private 'stateShort' => string 'GA' (length=2)
      private 'postalCode' => string '30035-2906' (length=10)
      private 'latitude' => string '33.7231545142857' (length=16)
      private 'longitude' => string '-84.2125686428571' (length=17)
      private 'timezone' => 
        object(DateTimeZone)[3129]
          public 'timezone_type' => int 3
          public 'timezone' => string 'America/New_York' (length=16)
```

After change:

```
array (size=1)
  0 => 
    object(Ziptastic\Ziptastic\LookupModel)[10049]
      private 'county' => string 'Providence' (length=10)
      private 'city' => string 'Providence' (length=10)
      private 'state' => string 'Rhode Island' (length=12)
      private 'stateShort' => string 'RI' (length=2)
      private 'postalCode' => string '02906' (length=5)
      private 'latitude' => float 41.8351
      private 'longitude' => float -71.3971
      private 'timezone' => 
        object(DateTimeZone)[10050]
          public 'timezone_type' => int 3
          public 'timezone' => string 'America/New_York' (length=16)
```
