### PR TITLE
Check for invalid timezones returned from the api and make the timezo…

### DIFF
--- a/src/LookupModel.php
+++ b/src/LookupModel.php
@@ -57,7 +57,7 @@ class LookupModel
         $this->latitude = $this->getOrNull('latitude', $lookup);
         $this->longitude = $this->getOrNull('longitude', $lookup);
         $timezone = $this->getOrNull('timezone', $lookup);
-        if (!is_null($timezone)) {
+        if (!is_null($timezone) && in_array($timezone, timezone_identifiers_list())) {
             $this->timezone = new DateTimeZone($timezone);
         }
     }

--- a/tests/LookupModelTest.php
+++ b/tests/LookupModelTest.php
@@ -43,4 +43,24 @@ class LookupModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($model->longitude());
         $this->assertNull($model->timezone());
     }
+
+    public function testInvalidTimezoneReturnsNull()
+    {
+        // as of 6/21/17, searching zipcode 59018 returns timezone 'n/a'
+        // this results in a warning at runtime because
+        // the lookup model expected null or a valid timezone only
+        $data = [
+            'county' => 'Park',
+            'city' => 'Clyde Park',
+            'state' => 'Michigan',
+            'state_short' => 'MT',
+            'postal_code' => '59018',
+            'latitude' => 45.8341,
+            'longitude' => -110.6222,
+            'timezone' => 'n/a'
+        ];
+
+        $model = new LookupModel($data);
+        $this->assertNull($model->timezone());
+    }
 }


### PR DESCRIPTION
As of 6/21/17, searching zipcode 59018 returns timezone 'n/a'.  This results in a warning at runtime because the lookup model expected null or a valid timezone only.

This fixes it to return null if an invalid timezone is returned from the API and gets rid of the warning.